### PR TITLE
Handle path parameters

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "typed-axios-instance",
-  "version": "1.0.7",
+  "version": "1.0.9",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "typed-axios-instance",
-      "version": "1.0.7",
+      "version": "1.0.9",
       "license": "ISC",
       "dependencies": {
         "ava": "^5.1.0",
@@ -22,7 +22,8 @@
         "@semantic-release/git": "^10.0.1",
         "@semantic-release/npm": "^9.0.2",
         "@semantic-release/release-notes-generator": "^10.0.3",
-        "prettier": "^2.8.3"
+        "prettier": "^2.8.3",
+        "type-fest": "^3.7.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -7586,6 +7587,17 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/serialize-error/node_modules/type-fest": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
+      "integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -8546,11 +8558,12 @@
       }
     },
     "node_modules/type-fest": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
-      "integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-3.7.0.tgz",
+      "integrity": "sha512-A2qUJ/j8vkKIT+UorxayZjFJoEdNkIPZkjOJSWezoAbRQd7QEhnz2iJlfVy4Or0GuEnCXts5cNorQNUvdLkaSQ==",
+      "dev": true,
       "engines": {
-        "node": ">=10"
+        "node": ">=14.16"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -14056,6 +14069,13 @@
       "integrity": "sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==",
       "requires": {
         "type-fest": "^0.13.1"
+      },
+      "dependencies": {
+        "type-fest": {
+          "version": "0.13.1",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
+          "integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg=="
+        }
       }
     },
     "shebang-command": {
@@ -14773,9 +14793,10 @@
       }
     },
     "type-fest": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
-      "integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg=="
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-3.7.0.tgz",
+      "integrity": "sha512-A2qUJ/j8vkKIT+UorxayZjFJoEdNkIPZkjOJSWezoAbRQd7QEhnz2iJlfVy4Or0GuEnCXts5cNorQNUvdLkaSQ==",
+      "dev": true
     },
     "typescript": {
       "version": "4.9.4",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "@semantic-release/git": "^10.0.1",
     "@semantic-release/npm": "^9.0.2",
     "@semantic-release/release-notes-generator": "^10.0.3",
-    "prettier": "^2.8.3"
+    "prettier": "^2.8.3",
+    "type-fest": "^3.7.0"
   }
 }

--- a/tests/example-route-types.ts
+++ b/tests/example-route-types.ts
@@ -74,3 +74,20 @@ export type ExampleRouteTypes3 = {
     }
   }
 }
+
+export type ExampleRouteTypes4 = {
+  "/things/[thing_id]/get": {
+    route: "/things/[thing_id]/get"
+    method: "POST" | "GET"
+    queryParams: {}
+    commonParams: {}
+    formData: {}
+    jsonResponse: {
+      thing: {
+        thing_id: string
+        name: string
+        created_at: string
+      }
+    }
+  }
+}

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -1,7 +1,11 @@
 import test from "ava"
 import { expectTypeOf } from "expect-type"
-import { MatchingRoute, TypedAxios } from "../src"
-import { ExampleRouteTypes1, ExampleRouteTypes3 } from "./example-route-types"
+import { TypedAxios } from "../src"
+import {
+  ExampleRouteTypes1,
+  ExampleRouteTypes3,
+  ExampleRouteTypes4,
+} from "./example-route-types"
 
 test("TypedAxios should create nicely typed AxiosInstance", async (t) => {
   const axios: TypedAxios<ExampleRouteTypes1> = null as any
@@ -25,6 +29,9 @@ test("TypedAxios should create nicely typed AxiosInstance", async (t) => {
 
   // @ts-expect-error
   axios.post("/things/create", {})
+
+  // @ts-expect-error (wrong method)
+  axios.get("/things/create")
 })
 
 test("works with RouteDef object that has multiple methods", async (t) => {
@@ -34,6 +41,19 @@ test("works with RouteDef object that has multiple methods", async (t) => {
       thing_id: "123",
     },
   })
+
+  expectTypeOf(getRes.data).toMatchTypeOf<{
+    thing: {
+      thing_id: string
+      name: string
+      created_at: string
+    }
+  }>()
+})
+
+test("parses path parameters", async (t) => {
+  const axios: TypedAxios<ExampleRouteTypes4> = null as any
+  const getRes = await axios.get("/things/10/get")
 
   expectTypeOf(getRes.data).toMatchTypeOf<{
     thing: {


### PR DESCRIPTION
Now parses and correctly types routes that have a path paramter (like `/things/[thing_id]/get`).

Turned into a bit of a larger refactor so that the API def is always a union rather than being either `RouteDef[]` or `Record<string, RouteDef>`.
