### PR TITLE
Select most specific route available if multiple match

### DIFF
--- a/tests/example-route-types.ts
+++ b/tests/example-route-types.ts
@@ -119,3 +119,34 @@ export type ExampleRouteTypes4 = {
     }
   }
 }
+
+export type WildcardAndSpecificEndpointExample = {
+  "/things/[thing_id]": {
+    route: "/things/[thing_id]"
+    method: "GET"
+    queryParams: {}
+    commonParams: {}
+    formData: {}
+    jsonResponse: {
+      thing_get: {
+        thing_id: string
+        name: string
+        created_at: string
+      }
+    }
+  }
+  "/things/all": {
+    route: "/things/all"
+    method: "GET"
+    queryParams: {}
+    commonParams: {}
+    formData: {}
+    jsonResponse: {
+      all_things: Array<{
+        thing_id: string
+        name: string
+        created_at: string
+      }>
+    }
+  }
+}

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -5,6 +5,7 @@ import {
   ExampleRouteTypes1,
   ExampleRouteTypes3,
   ExampleRouteTypes4,
+  WildcardAndSpecificEndpointExample,
 } from "./example-route-types"
 
 test("TypedAxios should create nicely typed AxiosInstance", async (t) => {
@@ -71,5 +72,27 @@ test("parses path parameters", async (t) => {
       name: string
       created_at: string
     }
+  }>()
+})
+
+test("selects most specific type available", async (t) => {
+  const axios: TypedAxios<WildcardAndSpecificEndpointExample> = null as any
+
+  const getByIdRes = await axios.get("/things/10")
+  expectTypeOf(getByIdRes.data).toMatchTypeOf<{
+    thing_get: {
+      thing_id: string
+      name: string
+      created_at: string
+    }
+  }>()
+
+  const getAllRes = await axios.get("/things/all")
+  expectTypeOf(getAllRes.data).toMatchTypeOf<{
+    all_things: Array<{
+      thing_id: string
+      name: string
+      created_at: string
+    }>
   }>()
 })


### PR DESCRIPTION
Closes https://github.com/seamapi/typed-axios/issues/8.

Also removed some unused types.

The main limitation of this approach is that it works for `/devices/all,/devices/${string}` but not for `/hubs/${string}/devices/${string},/hubs/${string}/devices/all`. However I can't think of a good way to handle this generally without implementing both a scoring system for how specific routes are and sorting within the type system. 😅 
