### PR TITLE
typesafe URL encoded form data

### DIFF
--- a/ava.config.js
+++ b/ava.config.js
@@ -1,5 +1,5 @@
 module.exports = {
-  files: ["src/tests/**/*.test.ts"],
+  files: ["tests/**/*.test.ts"],
   extensions: ["ts"],
   require: ["esbuild-register"],
   ignoredByWatcher: [".next", ".nsm"],

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "typed-axios-instance",
-  "version": "1.0.11",
+  "version": "1.0.13",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "typed-axios-instance",
-      "version": "1.0.11",
+      "version": "1.0.13",
       "license": "ISC",
       "devDependencies": {
         "@semantic-release/commit-analyzer": "^9.0.2",
@@ -22,6 +22,10 @@
         "tsup": "^6.5.0",
         "type-fest": "^3.7.0",
         "typescript": "^4.9.4"
+      },
+      "peerDependencies": {
+        "axios": ">=1.0.0",
+        "type-fest": ">=3.0.0"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "types": "dist/index.d.ts",
   "scripts": {
     "build": "tsup ./src --dts --sourcemap",
-    "test": "npm run typecheck",
+    "test": "npm run typecheck && ava",
     "format": "prettier -w .",
     "typecheck": "tsc --noEmit"
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -244,6 +244,8 @@ export type TypedURLSearchParams<_T> = URLSearchParams & {
   __URLSearchParamsType?: _T
 }
 
-export const routeUrlEncodedData = <T>(data: T): TypedURLSearchParams<T> => {
+export const createTypedURLSearchParams = <T>(
+  data: T
+): TypedURLSearchParams<T> => {
   return new URLSearchParams(data as any)
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -232,3 +232,28 @@ export interface TypedAxios<
     config: Config
   ): Promise<AxiosResponse<RouteResponse<Routes, URL, Config["method"]>>>
 }
+
+export const routeFormData =
+  <
+    T extends APIDef,
+    Routes extends RouteDef = ExplodeMethodsOnRouteDef<
+      ReplacePathParamsOnRouteDef<APIDefToUnion<T>>
+    >
+    // currying is necessary to work around lack of partial type argument
+    // inference support in typescript
+  >() =>
+  <
+    URL extends PathWithMethod<Routes, "POST">,
+    MR extends RouteDef = MatchingRoute<Routes, URL, "POST">
+  >(
+    _url: URL,
+    data: MR["formData"]
+  ) => {
+    const formData = new FormData()
+
+    for (const [key, value] of Object.entries(data ?? {})) {
+      formData.append(key, (value as any).toString())
+    }
+
+    return formData
+  }

--- a/tests/example-route-types.ts
+++ b/tests/example-route-types.ts
@@ -150,3 +150,18 @@ export type WildcardAndSpecificEndpointExample = {
     }
   }
 }
+
+export type FormDataExample = {
+  "/things/create": {
+    route: "/things/create"
+    method: "POST"
+    queryParams: {}
+    commonParams: {}
+    formData: {
+      resourceId: number
+      timestamp: string
+      slug: string
+    }
+    jsonResponse: {}
+  }
+}

--- a/tests/http-method-discrimination.test.ts
+++ b/tests/http-method-discrimination.test.ts
@@ -3,52 +3,58 @@ import { expectTypeOf } from "expect-type"
 import { MatchingRoute, TypedAxios } from "../src"
 import { ExampleRouteTypes2 } from "./example-route-types"
 
-test("TypedAxios should be able to discriminate http method request differences", async (t) => {
-  const axios: TypedAxios<ExampleRouteTypes2> = null as any
+test.failing(
+  "TypedAxios should be able to discriminate http method request differences",
+  async (t) => {
+    const axios: TypedAxios<ExampleRouteTypes2> = null as any
 
-  type RouteArr = ExampleRouteTypes2[number]
-  type K = Extract<
-    RouteArr,
-    { route: "/things/create"; method: "PATCH" }
-  >["jsonBody"]
+    type RouteArr = ExampleRouteTypes2[number]
+    type K = Extract<
+      RouteArr,
+      { route: "/things/create"; method: "PATCH" }
+    >["jsonBody"]
 
-  const createRes = await axios.post("/things/create", {
-    serial_number: 123,
-    name: "thing",
-  })
-  expectTypeOf(createRes.data).toMatchTypeOf<{
-    thing: {
-      thing_id: string
-      name: string
-      created_at: string
-    }
-  }>()
-
-  // @ts-expect-error
-  axios.post("/things/create", { name: 123 })
-
-  // @ts-expect-error
-  axios.post("/tings/crate", { name: "123" })
-
-  // @ts-expect-error
-  axios.post("/things/create")
-
-  // @ts-expect-error
-  axios.post("/things/create", {})
-
-  expectTypeOf(
-    axios.patch("/things/create", { name: "new_thing_name" })
-  ).resolves.toMatchTypeOf<{
-    data: {
+    const createRes = await axios.post("/things/create", {
+      serial_number: 123,
+      name: "thing",
+    })
+    expectTypeOf(createRes.data).toMatchTypeOf<{
       thing: {
         thing_id: string
         name: string
         created_at: string
       }
-    }
-  }>()
+    }>()
 
-  // The PATCH method can't update the serial number
-  // @ts-expect-error
-  axios.patch("/things/create", { serial_number: 123, name: "new_thing_name" })
-})
+    // @ts-expect-error
+    axios.post("/things/create", { name: 123 })
+
+    // @ts-expect-error
+    axios.post("/tings/crate", { name: "123" })
+
+    // @ts-expect-error
+    axios.post("/things/create")
+
+    // @ts-expect-error
+    axios.post("/things/create", {})
+
+    expectTypeOf(
+      axios.patch("/things/create", { name: "new_thing_name" })
+    ).resolves.toMatchTypeOf<{
+      data: {
+        thing: {
+          thing_id: string
+          name: string
+          created_at: string
+        }
+      }
+    }>()
+
+    // The PATCH method can't update the serial number
+    axios.patch("/things/create", {
+      // @ts-expect-error
+      serial_number: 123,
+      name: "new_thing_name",
+    })
+  }
+)

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -1,58 +1,65 @@
 import test from "ava"
 import { expectTypeOf } from "expect-type"
-import { TypedAxios } from "../src"
+import { TypedAxios, routeFormData } from "../src"
 import {
   ExampleRouteTypes1,
   ExampleRouteTypes3,
   ExampleRouteTypes4,
+  FormDataExample,
   WildcardAndSpecificEndpointExample,
 } from "./example-route-types"
 
-test("TypedAxios should create nicely typed AxiosInstance", async (t) => {
-  const axios: TypedAxios<ExampleRouteTypes1> = null as any
-  const createRes = await axios.post("/things/create", { name: "thing" })
-  expectTypeOf(createRes.data).toMatchTypeOf<{
-    thing: {
-      thing_id: string
-      name: string
-      created_at: string
-    }
-  }>()
+test.failing(
+  "TypedAxios should create nicely typed AxiosInstance",
+  async (t) => {
+    const axios: TypedAxios<ExampleRouteTypes1> = null as any
+    const createRes = await axios.post("/things/create", { name: "thing" })
+    expectTypeOf(createRes.data).toMatchTypeOf<{
+      thing: {
+        thing_id: string
+        name: string
+        created_at: string
+      }
+    }>()
 
-  // @ts-expect-error
-  axios.post("/things/create", { name: 123 })
+    // @ts-expect-error
+    axios.post("/things/create", { name: 123 })
 
-  // @ts-expect-error
-  axios.post("/tings/crate", { name: "123" })
+    // @ts-expect-error
+    axios.post("/tings/crate", { name: "123" })
 
-  // @ts-expect-error
-  axios.post("/things/create")
+    // @ts-expect-error
+    axios.post("/things/create")
 
-  // @ts-expect-error
-  axios.post("/things/create", {})
+    // @ts-expect-error
+    axios.post("/things/create", {})
 
-  // @ts-expect-error (wrong method)
-  axios.get("/things/create")
-})
+    // @ts-expect-error (wrong method)
+    axios.get("/things/create")
+  }
+)
 
-test("works with RouteDef object that has multiple methods", async (t) => {
-  const axios: TypedAxios<ExampleRouteTypes3> = null as any
-  const getRes = await axios.get("/things/get", {
-    params: {
-      thing_id: "123",
-    },
-  })
+test.failing(
+  "works with RouteDef object that has multiple methods",
+  async (t) => {
+    const axios: TypedAxios<ExampleRouteTypes3> = null as any
+    const getRes = await axios.get("/things/get", {
+      params: {
+        thing_id: "123",
+      },
+    })
 
-  expectTypeOf(getRes.data).toMatchTypeOf<{
-    thing: {
-      thing_id: string
-      name: string
-      created_at: string
-    }
-  }>()
-})
+    expectTypeOf(getRes.data).toMatchTypeOf<{
+      thing: {
+        thing_id: string
+        name: string
+        created_at: string
+      }
+    }>()
+  }
+)
 
-test("parses path parameters", async (t) => {
+test.failing("parses path parameters", async (t) => {
   const axios: TypedAxios<ExampleRouteTypes4> = null as any
   const getRes = await axios.get("/things/10/get")
 
@@ -75,7 +82,7 @@ test("parses path parameters", async (t) => {
   }>()
 })
 
-test("selects most specific type available", async (t) => {
+test.failing("selects most specific type available", async (t) => {
   const axios: TypedAxios<WildcardAndSpecificEndpointExample> = null as any
 
   const getByIdRes = await axios.get("/things/10")
@@ -95,4 +102,19 @@ test("selects most specific type available", async (t) => {
       created_at: string
     }>
   }>()
+})
+
+test("can create FormData", async (t) => {
+  const axios: TypedAxios<FormDataExample> = null as any
+
+  const formData = routeFormData<FormDataExample>()("/things/create", {
+    resourceId: 123,
+    slug: "cool-resource",
+    timestamp: new Date().toISOString(),
+  })
+
+  t.log({ formData })
+
+  t.is(formData.get("resourceId"), "123")
+  t.is(formData.get("slug"), "cool-resource")
 })

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -1,7 +1,7 @@
 import { toFormData } from "axios"
 import test from "ava"
 import { expectTypeOf } from "expect-type"
-import { TypedAxios, routeUrlEncodedData } from "../src"
+import { TypedAxios, createTypedURLSearchParams } from "../src"
 import {
   ExampleRouteTypes1,
   ExampleRouteTypes3,
@@ -114,7 +114,7 @@ test("can create FormData", async (t) => {
     timestamp: new Date().toISOString(),
   }
 
-  const encodedData = routeUrlEncodedData(formData)
+  const encodedData = createTypedURLSearchParams(formData)
 
   try {
     await axios.post("/things/create", encodedData)
@@ -122,7 +122,7 @@ test("can create FormData", async (t) => {
     await axios.post(
       "/things/create",
       // @ts-expect-error
-      routeUrlEncodedData({
+      createTypedURLSearchParams({
         resourceId: 123,
         slug: "cool-resource",
       })


### PR DESCRIPTION
Forces typesafe url encoded form data for `post` calls.

This is a breaking change since it forces all consumers to use `routeUrlEncodedData` as a typesafe wrapper for URL-encoded forms.

We can't use `postForm` for this since that's multipart form data, rather than URL encoded.