### PR TITLE
Add support for `urlEncodedFormData`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -77,6 +77,11 @@ export interface AxiosConfigForRouteDef<Route extends RouteDef>
   data?: Route["jsonBody"] & Route["commonParams"]
 }
 
+type FormDataFromRouteDef<Route extends RouteDef> =
+  keyof Route["formData"] extends never
+    ? Route["urlEncodedFormData"]
+    : Route["formData"]
+
 export interface TypedAxios<
   T extends APIDef,
   Routes extends RouteDef = ExplodeMethodsOnRouteDef<
@@ -91,7 +96,7 @@ export interface TypedAxios<
     MR extends RouteDef = MatchingRoute<Routes, URL, "POST">
   >(
     url: URL,
-    ...args: keyof MR["formData"] extends never
+    ...args: keyof FormDataFromRouteDef<MR> extends never
       ? keyof MR["jsonBody"] extends never
         ? [data?: any, config?: Omit<AxiosConfigForRouteDef<MR>, "data">]
         : [
@@ -99,7 +104,7 @@ export interface TypedAxios<
             config?: Omit<AxiosConfigForRouteDef<MR>, "data">
           ]
       : [
-          data: TypedURLSearchParams<MR["formData"]>,
+          data: TypedURLSearchParams<FormDataFromRouteDef<MR>>,
           config?: Omit<AxiosConfigForRouteDef<MR>, "data">
         ]
   ): Promise<AxiosResponse<MR["jsonResponse"]>>
@@ -152,7 +157,7 @@ export interface TypedAxios<
     MR extends RouteDef = MatchingRoute<Routes, URL, "POST">
   >(
     url: URL,
-    data: MR["formData"],
+    data: FormDataFromRouteDef<MR>,
     config?: Omit<AxiosConfigForRouteDef<MR>, "data">
   ): Promise<AxiosResponse<MR["jsonResponse"]>>
   putForm<
@@ -160,7 +165,7 @@ export interface TypedAxios<
     MR extends RouteDef = MatchingRoute<Routes, URL, "PUT">
   >(
     url: URL,
-    data: MR["formData"],
+    data: FormDataFromRouteDef<MR>,
     config?: Omit<AxiosConfigForRouteDef<MR>, "data">
   ): Promise<AxiosResponse<MR["jsonResponse"]>>
   patchForm<
@@ -168,7 +173,7 @@ export interface TypedAxios<
     MR extends RouteDef = MatchingRoute<Routes, URL, "PATCH">
   >(
     url: URL,
-    data: MR["formData"],
+    data: FormDataFromRouteDef<MR>,
     config?: Omit<AxiosConfigForRouteDef<MR>, "data">
   ): Promise<AxiosResponse<MR["jsonResponse"]>>
   request<

--- a/src/route-def.ts
+++ b/src/route-def.ts
@@ -8,6 +8,7 @@ export type RouteDef = {
   commonParams?: Record<string, any>
   formData?: Record<string, any>
   jsonResponse?: Record<string, any>
+  urlEncodedFormData?: Record<string, any>
   // TODO support error responses
 }
 

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -165,3 +165,30 @@ test.failing("Empty Data", async (t) => {
     }
   }>()
 })
+
+test.failing("urlEncodedFormData", async () => {
+  const axios: TypedAxios<{
+    "/things/create": {
+      route: "/things/create"
+      method: "POST"
+      urlEncodedFormData: {
+        thing_name: string
+      }
+    }
+  }> = null as any
+
+  await axios.post(
+    "/things/create",
+    // @ts-expect-error wrong payload
+    createTypedURLSearchParams({
+      foo: "bar",
+    })
+  )
+
+  await axios.post(
+    "/things/create",
+    createTypedURLSearchParams({
+      thing_name: "bar",
+    })
+  )
+})


### PR DESCRIPTION
EdgeSpec distinguishes between multipart form data and URL encoded form data.
